### PR TITLE
added lower resolution timer example

### DIFF
--- a/systemd/transmission.timer
+++ b/systemd/transmission.timer
@@ -4,7 +4,13 @@ Description=Trigger Transmission
 
 [Timer]
 OnActiveSec=10sec
+
+#5 minute loop for environments that require a high resolution
 OnUnitActiveSec=5min
+
+#12 hour loop for larger environments where a higher resolution is undesireable and randomization helps to spreads out peak loads.
+#OnUnitActiveSec=12h
+#RandomizedDelaySec=39600
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
A very minor tweak to make it easier for someone less familiar with systemd semantics. This would help users who can't support a large number of systems "calling home" every 5 minutes. I left the defaults as it's probably more useful for testing/demoing. 